### PR TITLE
fix for crash on Windows

### DIFF
--- a/mptools/_mptools.py
+++ b/mptools/_mptools.py
@@ -107,7 +107,8 @@ def default_signal_handler(signal_object, exception_class, signal_num, current_s
 def init_signal(signal_num, signal_object, exception_class, handler):
     handler = functools.partial(handler, signal_object, exception_class)
     signal.signal(signal_num, handler)
-    signal.siginterrupt(signal_num, False)
+    if sys.platform != "win32":
+        signal.siginterrupt(signal_num, False)
 
 
 def init_signals(shutdown_event, int_handler, term_handler):


### PR DESCRIPTION
SIGINT is n/a on Windows, with no easy replacement, hence the added condition